### PR TITLE
Issue #47 완료

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -18,6 +18,10 @@ class CommentAdmin(admin.ModelAdmin):
     list_display_links = ["content", ]
 
 
+class PickAdmin(admin.ModelAdmin):
+    list_display = ["id", "get_username", "round_id"]
+
+
 class RoundAdmin(admin.ModelAdmin):
     list_display = ["id", "question", ]
     list_display_links = ["question", ]
@@ -25,6 +29,6 @@ class RoundAdmin(admin.ModelAdmin):
 # Register your models here.
 admin.site.register(BackgroundImage, BackgroundImageAdmin)
 admin.site.register(Comment, CommentAdmin)
-admin.site.register(Pick)
+admin.site.register(Pick, PickAdmin)
 admin.site.register(Round, RoundAdmin)
 admin.site.register(RoundNickname)

--- a/apps/admin.py
+++ b/apps/admin.py
@@ -4,6 +4,7 @@ from .models import BackgroundImage
 from .models import Comment
 from .models import Pick
 from .models import Round
+from .models import RoundNickname
 
 
 # Define ModelAdmins
@@ -24,5 +25,6 @@ class RoundAdmin(admin.ModelAdmin):
 # Register your models here.
 admin.site.register(BackgroundImage, BackgroundImageAdmin)
 admin.site.register(Comment, CommentAdmin)
-admin.site.register(Round, RoundAdmin)
 admin.site.register(Pick)
+admin.site.register(Round, RoundAdmin)
+admin.site.register(RoundNickname)

--- a/apps/models.py
+++ b/apps/models.py
@@ -96,6 +96,9 @@ class Pick(models.Model):
     def __str__(self):
         return str(self.id)
 
+    def get_username(self):
+        return self.user_id.fb_id
+
 
 class Comment(models.Model):
     content = models.CharField(max_length=500)

--- a/apps/models.py
+++ b/apps/models.py
@@ -115,6 +115,7 @@ class Comment(models.Model):
     def get_round_id(self):
         return str(self.pick_id.round_id)
 
+
 class CommentLike(models.Model):
     create_date = models.DateTimeField(auto_now_add=True)
     user_id = models.ForeignKey(settings.AUTH_USER_MODEL)

--- a/apps/serializers.py
+++ b/apps/serializers.py
@@ -93,10 +93,11 @@ class CommentSerializer(serializers.ModelSerializer):
 
 class RecommentSerializer(serializers.ModelSerializer):
     is_liked = serializers.SerializerMethodField(method_name="like_or_not")
+    nickname = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
-        fields = ("id", "content", "like", "is_liked", "create_date", "comment_id")
+        fields = ("id", "nickname", "content", "like", "is_liked", "create_date", "comment_id")
         read_only_fields = ("id", "like", "is_liked", "create_date", )
 
     def like_or_not(self, obj):
@@ -106,6 +107,12 @@ class RecommentSerializer(serializers.ModelSerializer):
             return True
         except ObjectDoesNotExist:
             return False
+
+    def get_nickname(self, obj):
+        # obj(Comment)의 정보를 가지고 대응되는 RoundNickname 인스턴스를 검색
+        pick_id = obj.pick_id
+        roundnickname = RoundNickname.objects.get(user_id=pick_id.user_id, round_id=pick_id.round_id)
+        return roundnickname.nickname_id.nickname
 
     def create(self, validated_data):
         comment = Comment(**validated_data)


### PR DESCRIPTION
`Comment` 리스트를 반환하는 API에서 nickname 값을 보여줘야하는 이슈가 있었죠.
`Serializer` 단에서 `method`를 하나 더 추가하는 방법으로 구현해봤습니다.
간단한 테스트도 진행했는데 통과했네요.

개인적인 생각으로,
"`Comment` 인스턴스에서, 해당 comment를 작성한 유저의 `RoundNickname`을 받아온다"
는 희망사항의 구현은 `Comment`의 `model method`로 구현되면 가장 예쁘겠다는 생각이 드네요.

그러나 현재 구현에서는 어찌됬든 `RoundNickname`의 `model manager`를 사용해야하는데,
`Comment`의 `model method`에서 다른 model의 manager를 호출한다는게 꺼림찍하여,
`Serializer` 단에서 구현했습니다.

제가 생각하기로 가장 좋은 방법은,
`RoundNickname` 모델의 schema를 변경해서,
`user_id`, `round_id`를 ForeignKey로 가지고 있기 보다는, `pick_id`를 OneToOneField로 가지고 있도록 수정하고,
깔끔한 형태로 `Comment`의 `model method`를 정의하는 방법입니다.

말이 복잡해지네요...
더 논의가 필요하겠습니다 ㅎㅎ
